### PR TITLE
adds fallback on http if bitswap is slow

### DIFF
--- a/binary/main.go
+++ b/binary/main.go
@@ -85,8 +85,10 @@ func download(ctx context.Context, node pinner.PinnerNode) {
 	//ccid, err := cid.Parse("bafybeifzst7cbujrqemiulznrkttouzshnqkrajiib5fp5te53ojs5sl5u") // file encapsulated in folder
 	//ccid, err := cid.Parse("QmeFd8e4UaAPrPnwxBWcpqY3tMpggpWB3XYqftMpyYYLWZ") // straight up file
 
-	ccid, err := cid.Parse("bafybeifzst7cbujrqemiulznrkttouzshnqkrajiib5fp5te53ojs5sl5u")
-	//ccid, err := cid.Parse("bafybeic7nbudupk56j2ixdrczddzmuu3qtmlyrpqjxuy4jkaeeaminxq3e") // took about 12-15 minutes
+	//ccid, err := cid.Parse("bafybeifzst7cbujrqemiulznrkttouzshnqkrajiib5fp5te53ojs5sl5u")
+	//ccid, err := cid.Parse("QmZrxsDZwrCKbcJLNf1D6GaX2fobHZpesBc3DwhVBLQ33p")
+	//ccid, err := cid.Parse("bafkreic7xhzqyube57gex7okhzytg7i5eq6fvz5snpte7swy547s22bs5q")
+	ccid, err := cid.Parse("bafybeic7nbudupk56j2ixdrczddzmuu3qtmlyrpqjxuy4jkaeeaminxq3e") // took about 12-15 minutes
 
 	if err != nil {
 		log.Fatalf("%v", err)

--- a/core/ipfs.go
+++ b/core/ipfs.go
@@ -15,7 +15,7 @@ import (
 )
 
 // returns a go-ipfs node backend CoreAPI instance
-func CreateIpfsNnode(cidComputeOnly bool) (*core.IpfsNode, error) {
+func CreateIpfsNode(cidComputeOnly bool) (*core.IpfsNode, error) {
 	cfg := core.BuildCfg{
 		Online:    !cidComputeOnly, // networking
 		Permanent: !cidComputeOnly, // data persists across restarts?

--- a/dag/api.go
+++ b/dag/api.go
@@ -24,6 +24,7 @@ type UnixfsAPI interface {
 	// get the data stored in ipfs referenced by cid.
 	// If the node is online (networking enabled), this would also search
 	// in other ipfs nodes (using bitswap).
+	// NOTE: there's a timeout on bitswap method, after which, http is attempted.
 	// If the dag is cleaned up from local store, it might take time for the
 	// data to be pinned/available on remote nodes, which means that a "upload"
 	// followed immediately by a "get" might not work.

--- a/pinner.go
+++ b/pinner.go
@@ -24,7 +24,7 @@ type pinnerNode struct {
 
 func NewPinnerNode(req PinnerNodeCreateRequest) PinnerNode {
 	node := pinnerNode{}
-	ipfsNode, err := core.CreateIpfsNnode(req.cidComputeOnly)
+	ipfsNode, err := core.CreateIpfsNode(req.cidComputeOnly)
 	if err != nil {
 		logger.Fatal("error initializing ipfs node: ", err)
 	}


### PR DESCRIPTION
- the GET performance is assumed to evaluated on most of the queries being able to be fetched from local.
- for cases like unit tests, this might not be the case and causes slow queries. Adding timeout on bitswap fetch attempt, after which dweb.link http request is tried.