### PR TITLE
Upload refactor to accept direct content as multipart/form-data rather than filepath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.dll
 *.so
 *.dylib
+server/server
+binary/binary
+build/
 
 # Test binary, built with `go test -c`
 *.test
@@ -16,3 +19,4 @@
 
 .vscode/
 .DS_Store
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+GO = go # if using docker, should not need to be installed/linked
+GOBIN = $(CURDIR)/build/bin/
+DBG_CGO_CFLAGS += -DMDBX_DEBUG=1
+
+
+
+GO_DBG_BUILD = $(DBG_CGO_CFLAGS) $(GO) build -tags $(BUILD_TAGS),debug -gcflags=all="-N -l"  # see delve docs
+
+binary-dbg:
+	$(GO_DBG_BUILD) -o $(GOBIN)/ ./binary/
+
+server-dbg:
+	$(GO_DBG_BUILD) -o $(GOBIN) ./server/
+
+run:
+	$(GOBIN)/server
+
+clean:
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ipfs-pinner can be run as a server and allows two functionalities currently - `/
 
 to start a server which listens for request on a particular port, run:
 ```bash
-go run main.go -port 3000 -jwt "<jwt_token>"
+make clean server-dbg run
 ```
 
 - submit a request to upload a file:
@@ -85,7 +85,7 @@ docker container run --detach --name ipfs-pinner-instance \
        --volume /tmp/data/network_artifacts/specimens:/tmp/network_artifacts/specimens \
        --volume /tmp/data/.ipfs/:/root/.ipfs/  \
        -p 4001:4001 -p 3000:3000  \
-       --env WEB3_JWT=$WEB3_JWT bd08a7191c6a \
+       --env WEB3_JWT=$WEB3_JWT \
     <container-image-id>
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ to start a server which listens for request on a particular port, run:
 make clean server-dbg run
 ```
 
-- submit a request to upload a file:
+- submit a request to upload a file (using multipart/form-data):
 ```bash
-➜ curl -XGET http://127.0.0.1:3000/upload\?filePath\=/Users/sudeep/repos/elixir-koans/mix.exs
+➜ curl -F "filedata=@file_to_upload" http://127.0.0.1:3000/upload
 {"cid": "QmUqcL1RwbnbQ3FzmnT1aeRk8g8L5naKinJd5hCuPXxbZ2"}
 ```
 
 - failures will be reported (via "error" field in the json). E.g:
 ```bash
-➜ curl -XGET http://127.0.0.1:3000/upload\?filePath\=not_exist_file
+➜ curl -F "filedata=@non_existent_file" http://127.0.0.1:3000/upload
 {"error": "open not_exist_file: no such file or directory"}
 ```
 
@@ -82,7 +82,6 @@ Now, we can run the container:
 
 ```bash
 docker container run --detach --name ipfs-pinner-instance \
-       --volume /tmp/data/network_artifacts/specimens:/tmp/network_artifacts/specimens \
        --volume /tmp/data/.ipfs/:/root/.ipfs/  \
        -p 4001:4001 -p 3000:3000  \
        --env WEB3_JWT=$WEB3_JWT \
@@ -92,13 +91,7 @@ docker container run --detach --name ipfs-pinner-instance \
 
 ### Notes on Docker Volume setup
 
-There are 2 docker volumes that need to be shared (and persisted) between the container and the host - the first is the "source" directory of network artifacts which must be available to the container (for the /upload endpoint). Note that this endpoint takes an absolute file path, and so the volume is mapped to the same path inside the container to avoid the need to do any path translations/remapping inside ipfs-pinner.  
-
-Secondly, the .ipfs directory also needs to have its lifecycle unaffected by container lifecycle (since it contains the merklelized nodes, blockstore etc.), and so that is also docker volume managed.  
-
-If there are more "source" directories, additional `--volume` flags can be passed into the docker container run command. <B>But note that to prevent the remapping issue, the paths in the host and the container need to be the same.</B>   
-In the example above `/tmp/data/network_artifacts/specimens` points to the same path in container.
-
+There's 1 docker volumes that need to be shared (and persisted) between the container and the host - the .ipfs directory needs to have its lifecycle unaffected by container lifecycle (since it contains the merklelized nodes, blockstore etc.), and so that is docker volume managed.  
 
 ### Notes on port mapping setup
 


### PR DESCRIPTION
- this makes it easier for the server process to run in isolated containers, without the need to expose volumes or do path translation