### PR TITLE
try bitswap in case peering is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 .vscode/
 .DS_Store
 .envrc
+dlv/

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ run:
 	$(GOBIN)/server
 
 clean:
-	rm -rf build
+	rm -rf build binary/binary server/server

--- a/coreapi/api.go
+++ b/coreapi/api.go
@@ -3,12 +3,14 @@ package coreapi
 import (
 	"context"
 
+	"github.com/ipfs/go-ipfs/config"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 )
 
 type CoreExtensionAPI interface {
 	coreiface.CoreAPI
 	GC() GarbageCollectAPI
+	Config() *config.Config
 }
 
 type GarbageCollectAPI interface {

--- a/coreapi/impl.go
+++ b/coreapi/impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ipfs/go-ipfs/config"
 	"github.com/ipfs/go-ipfs/core"
 	icore "github.com/ipfs/go-ipfs/core/coreapi"
 	corerepo "github.com/ipfs/go-ipfs/core/corerepo"
@@ -12,18 +13,24 @@ import (
 
 type coreApiImpl struct {
 	coreiface.CoreAPI
-	gci *garbageCollectorImpl
+	gci    *garbageCollectorImpl
+	config *config.Config
 }
 
 func NewCoreExtensionApi(ipfsNode *core.IpfsNode) CoreExtensionAPI {
 	impl := &coreApiImpl{}
 	impl.gci = &garbageCollectorImpl{node: ipfsNode}
 	impl.CoreAPI, _ = icore.NewCoreAPI(ipfsNode)
+	impl.config, _ = ipfsNode.Repo.Config()
 	return impl
 }
 
 func (impl *coreApiImpl) GC() GarbageCollectAPI {
 	return impl.gci
+}
+
+func (impl *coreApiImpl) Config() *config.Config {
+	return impl.config
 }
 
 type garbageCollectorImpl struct {


### PR DESCRIPTION
- when peering is available in the config. The bitswap search can prioritise those and return the result faster. This has been verified in the testing.
- the bitswap search in case of no peers is still slow, and so the offline and fallback logic on dweb.link is still kept around.