### PR TITLE
Implement health check for `ipfs-pinner` container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apk update && apk add --no-cache bash=5.1.16-r0
 COPY --from=builder /build/ipfs-server /app
 SHELL ["/bin/bash", "-c"]
 RUN chmod +x ./ipfs-server
+
+HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3000/health
+
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 CMD [ "./ipfs-server -port 3000 -jwt $WEB3_JWT" ]
 
@@ -26,5 +29,3 @@ EXPOSE 5001
 EXPOSE 8080
 # Swarm Websockets; must be exposed publicly when the node is listening using the websocket transport (/ipX/.../tcp/8081/ws).
 EXPOSE 8081
-
-HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3000/health || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,5 @@ EXPOSE 5001
 EXPOSE 8080
 # Swarm Websockets; must be exposed publicly when the node is listening using the websocket transport (/ipX/.../tcp/8081/ws).
 EXPOSE 8081
+
+HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3000/health || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'

--- a/core/support.go
+++ b/core/support.go
@@ -17,7 +17,7 @@ const (
 	// IpfsPinnerVersionMinor is Minor version component of the current release
 	IpfsPinnerVersionMinor = 1
 	// IpfsPinnerVersionPatch is Patch version component of the current release
-	IpfsPinnerVersionPatch = 11
+	IpfsPinnerVersionPatch = 12
 	clientIdentifier       = "ipfs-pinner" // Client identifier to advertise over the network
 )
 

--- a/openapi/api_filepin.go
+++ b/openapi/api_filepin.go
@@ -58,8 +58,8 @@ PinataFileUpload Upload file to IPFS
 
 pinata services' upload file to ipfs option
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPinataFileUploadRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPinataFileUploadRequest
 */
 func (a *FilepinApiService) PinataFileUpload(ctx context.Context) ApiPinataFileUploadRequest {
 	return ApiPinataFileUploadRequest{
@@ -69,7 +69,8 @@ func (a *FilepinApiService) PinataFileUpload(ctx context.Context) ApiPinataFileU
 }
 
 // Execute executes the request
-//  @return PinataResponse
+//
+//	@return PinataResponse
 func (a *FilepinApiService) PinataFileUploadExecute(r ApiPinataFileUploadRequest) (*PinataResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -253,8 +254,8 @@ Web3StorageCarUpload Upload car file to web3.storage
 
 Upload car file to web3.storage
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiWeb3StorageCarUploadRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiWeb3StorageCarUploadRequest
 */
 func (a *FilepinApiService) Web3StorageCarUpload(ctx context.Context) ApiWeb3StorageCarUploadRequest {
 	return ApiWeb3StorageCarUploadRequest{
@@ -264,7 +265,8 @@ func (a *FilepinApiService) Web3StorageCarUpload(ctx context.Context) ApiWeb3Sto
 }
 
 // Execute executes the request
-//  @return Web3StorageCarResponse
+//
+//	@return Web3StorageCarResponse
 func (a *FilepinApiService) Web3StorageCarUploadExecute(r ApiWeb3StorageCarUploadRequest) (*Web3StorageCarResponse, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost

--- a/openapi/api_pins.go
+++ b/openapi/api_pins.go
@@ -98,8 +98,8 @@ PinsGet List pin objects
 
 List all the pin objects, matching optional filters; when no filter is provided, only successful pins are returned
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPinsGetRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPinsGetRequest
 */
 func (a *PinsApiService) PinsGet(ctx context.Context) ApiPinsGetRequest {
 	return ApiPinsGetRequest{
@@ -109,7 +109,8 @@ func (a *PinsApiService) PinsGet(ctx context.Context) ApiPinsGetRequest {
 }
 
 // Execute executes the request
-//  @return PinResults
+//
+//	@return PinResults
 func (a *PinsApiService) PinsGetExecute(r ApiPinsGetRequest) (*PinResults, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -286,8 +287,8 @@ PinsPost Add pin object
 
 Add a new pin object for the current access token
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPinsPostRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPinsPostRequest
 */
 func (a *PinsApiService) PinsPost(ctx context.Context) ApiPinsPostRequest {
 	return ApiPinsPostRequest{
@@ -297,7 +298,8 @@ func (a *PinsApiService) PinsPost(ctx context.Context) ApiPinsPostRequest {
 }
 
 // Execute executes the request
-//  @return PinStatus
+//
+//	@return PinStatus
 func (a *PinsApiService) PinsPostExecute(r ApiPinsPostRequest) (*PinStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -450,9 +452,9 @@ PinsRequestidDelete Remove pin object
 
 Remove a pin object
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param requestid
- @return ApiPinsRequestidDeleteRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param requestid
+	@return ApiPinsRequestidDeleteRequest
 */
 func (a *PinsApiService) PinsRequestidDelete(ctx context.Context, requestid string) ApiPinsRequestidDeleteRequest {
 	return ApiPinsRequestidDeleteRequest{
@@ -601,9 +603,9 @@ PinsRequestidGet Get pin object
 
 Get a pin object and its status
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param requestid
- @return ApiPinsRequestidGetRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param requestid
+	@return ApiPinsRequestidGetRequest
 */
 func (a *PinsApiService) PinsRequestidGet(ctx context.Context, requestid string) ApiPinsRequestidGetRequest {
 	return ApiPinsRequestidGetRequest{
@@ -614,7 +616,8 @@ func (a *PinsApiService) PinsRequestidGet(ctx context.Context, requestid string)
 }
 
 // Execute executes the request
-//  @return PinStatus
+//
+//	@return PinStatus
 func (a *PinsApiService) PinsRequestidGetExecute(r ApiPinsRequestidGetRequest) (*PinStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -769,9 +772,9 @@ PinsRequestidPost Replace pin object
 
 Replace an existing pin object (shortcut for executing remove and add operations in one step to avoid unnecessary garbage collection of blocks present in both recursive pins)
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @param requestid
- @return ApiPinsRequestidPostRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param requestid
+	@return ApiPinsRequestidPostRequest
 */
 func (a *PinsApiService) PinsRequestidPost(ctx context.Context, requestid string) ApiPinsRequestidPostRequest {
 	return ApiPinsRequestidPostRequest{
@@ -782,7 +785,8 @@ func (a *PinsApiService) PinsRequestidPost(ctx context.Context, requestid string
 }
 
 // Execute executes the request
-//  @return PinStatus
+//
+//	@return PinStatus
 func (a *PinsApiService) PinsRequestidPostExecute(r ApiPinsRequestidPostRequest) (*PinStatus, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost

--- a/server/main.go
+++ b/server/main.go
@@ -303,7 +303,7 @@ func downloadHandler(cidStr string, node pinner.PinnerNode) ([]byte, error) {
 func healthHttpHandler(s *State) http.Handler {
 	// Check the health of the server and return a status code accordingly
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		log.Panicln("Received /health request:", "source=", r.RemoteAddr, "status=", s.status)
+		log.Println("Received /health request:", "source=", r.RemoteAddr, "status=", s.status)
 		switch s.status {
 		case OK:
 			io.WriteString(w, "I'm healthy")

--- a/server/main.go
+++ b/server/main.go
@@ -306,7 +306,10 @@ func healthHttpHandler(s *State) http.Handler {
 		log.Println("Received /health request:", "source=", r.RemoteAddr, "status=", s.status)
 		switch s.status {
 		case OK:
-			io.WriteString(w, "I'm healthy")
+			_, err := io.WriteString(w, "I'm healthy")
+			if err != nil {
+				log.Println("cannot write %w string", err)
+			}
 			return
 		case BAD:
 			http.Error(w, "Internal Error", 500)
@@ -315,7 +318,10 @@ func healthHttpHandler(s *State) http.Handler {
 			time.Sleep(30 * time.Second)
 			return
 		default:
-			io.WriteString(w, "UNKNOWN")
+			_, err := io.WriteString(w, "UNKNOWN")
+			if err != nil {
+				log.Println("cannot write %w string", err)
+			}
 			return
 		}
 	}
@@ -325,7 +331,10 @@ func healthHttpHandler(s *State) http.Handler {
 func sabotageHttpHandler(s *State) http.Handler {
 	fn := func(w http.ResponseWriter, _ *http.Request) {
 		s.status = BAD
-		io.WriteString(w, "Sabotage ON")
+		_, err := io.WriteString(w, "Sabotage ON")
+		if err != nil {
+			log.Println("cannot write %w string", err)
+		}
 	}
 	return http.HandlerFunc(fn)
 }
@@ -333,7 +342,10 @@ func sabotageHttpHandler(s *State) http.Handler {
 func recoverHttpHandler(s *State) http.Handler {
 	fn := func(w http.ResponseWriter, _ *http.Request) {
 		s.status = OK
-		io.WriteString(w, "Recovered.")
+		_, err := io.WriteString(w, "Recovered.")
+		if err != nil {
+			log.Println("cannot write %w string", err)
+		}
 	}
 	return http.HandlerFunc(fn)
 }
@@ -341,7 +353,10 @@ func recoverHttpHandler(s *State) http.Handler {
 func timeoutHttpHandler(s *State) http.Handler {
 	fn := func(w http.ResponseWriter, _ *http.Request) {
 		s.status = TIMEOUT
-		io.WriteString(w, "Configured to timeout.")
+		_, err := io.WriteString(w, "Configured to timeout.")
+		if err != nil {
+			log.Println("cannot write %w string", err)
+		}
 	}
 	return http.HandlerFunc(fn)
 }


### PR DESCRIPTION
Implementing health checks for [ipfs-pinner]() and [evm-server](https://github.com/covalenthq/erigon/pull/29) such that if the container fails - willfarrell/autoheal picks it up and restarts the entire container, supported with [rudder](https://github.com/covalenthq/rudder/pull/120)

- Simulate a failure (sending a 500 http server error) with an endpoint available called `/sabotage`
```
root@cqt-bsp-finalizer:~# docker exec -it a1ec0cf1f131 /bin/bash
bash-5.1# wget -nv --spider localhost:3000/sabotage
Connecting to localhost:3002 (127.0.0.1:3000)
remote file exists
```
- causes the `evm-server` to fail with /health status "BAD" leading to the restart 

```
May 02 01:23:27 cqt-bsp-finalizer docker[380649]: evm-server   | [INFO] [05-02|01:23:27.240] Received /health request:                source==127.0.0.1:44564 status==OK
May 02 01:23:27 cqt-bsp-finalizer docker[380649]: ipfs-pinner  | 2023/05/02 01:23:27 Received /health request: source= 127.0.0.1:57920 status= BAD
May 02 01:23:34 cqt-bsp-finalizer docker[380649]: autoheal     | 02-05-2023 01:23:34 Container /ipfs-pinner (3b77b2f7be81) found to be unhealthy - Restarting container now with 10s timeout
May 02 01:23:35 cqt-bsp-finalizer docker[380649]: ipfs-pinner exited with code 0
May 02 01:23:35 cqt-bsp-finalizer docker[380649]: ipfs-pinner exited with code 0
May 02 01:23:35 cqt-bsp-finalizer docker[380649]: ipfs-pinner  | ipfs-pinner
May 02 01:23:35 cqt-bsp-finalizer docker[380649]: ipfs-pinner  | ipfs-pinner Version: 0.1.12
May 02 01:23:35 cqt-bsp-finalizer docker[380649]: ipfs-pinner  | Architecture: amd64
```