### PR TITLE
upgrading alpine image version to latest stable 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go mod download && CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o ipfs-server ./server/main.go
 
 # Runtime -  second phase.
-FROM alpine:3.18.3
+FROM alpine:3.19
 RUN mkdir /app
 WORKDIR /app
 RUN apk update && apk add --no-cache bash=5.2.15-r5

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download && CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o 
 FROM alpine:3.19
 RUN mkdir /app
 WORKDIR /app
-RUN apk upgrade && apk add --no-cache bash=5.2.21-r0
+RUN apk update && apk add --no-cache bash=5.2.21-r0
 COPY --from=builder --chmod=700 /build/ipfs-server /app
 
 HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3001/health

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download && CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o 
 FROM alpine:3.19
 RUN mkdir /app
 WORKDIR /app
-RUN apk update && apk add --no-cache bash=5.2.15-r5
+RUN apk upgrade && apk add --no-cache bash=5.2.21-r0
 COPY --from=builder --chmod=700 /build/ipfs-server /app
 
 HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3001/health


### PR DESCRIPTION
This will point to any future minor patches. The builder stage golang:1.20-alpine already points to 3.19.