### PR TITLE
pin the w3cli version to v7.6.2 as newer versions introduce breaking …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download && CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o 
 FROM alpine:3.20
 RUN mkdir /app
 WORKDIR /app
-RUN apk update && apk add --no-cache bash nodejs npm git && npm install -g @web3-storage/w3cli
+RUN apk update && apk add --no-cache bash nodejs npm git && npm install -g @web3-storage/w3cli@v7.6.2
 COPY --from=builder --chmod=700 /build/ipfs-server /app
 
 RUN apk del git && rm -rf /var/cache/apk/* /root/.npm /tmp/*

--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ We'll use w3cli to login and create a new space and register.
 
 #### installation
 ```bash
-➜ npm install -g @web3-storage/w3cli
+➜ npm install -g @web3-storage/w3cli@v7.6.2
 
 ➜ w3 --version
-w3, 7.0.3
+w3, 7.6.2
 ```
 
 #### login and check spaces


### PR DESCRIPTION
…changes requiring additional capabilities on delegations